### PR TITLE
Fix stale check

### DIFF
--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -408,7 +408,8 @@ def main():
 
     # tmp file to log if start notifcation has been sent
     # open and close to create file in case its the first time
-    notify_log = f"{args.sequencer_id}.start_notify.log".strip('"\'')
+    notify_log = f"{args.sequencer_id}.start_notify.log"
+    notify_log = notify_log.replace('"', '').replace("'", "")
 
     with open(notify_log, 'a+') as fh:
         log = ' '.join(fh.readlines())

--- a/files/monitor_runs.py
+++ b/files/monitor_runs.py
@@ -232,15 +232,29 @@ def get_run_folders(base_dir):
 def check_local_runs(base_dir, run_folders, run_length, n_intervals, novaseq=False):
     """ Check local folders to ascertain which are Illumina RUN directories (defined
     as containing a RunInfo.xml file in root of the folder).
+
     Classify such RUN folders into 3 classes:
      - Completed runs (has a RunInfo.xml and a RTAComplete.txt/xml file)
      - In-progress run (has a RunInfo.xml file, but not a RTAComplete.txt/xml file)
      - Stale run (has a RunInfo.xml file, which was created more than Y times expected duration
        of a sequencing run, both the sequencing runtime and Y will be user-specified,
        with defaults of 2 and 24hrs respectively).
+
+    These are categorised into 5 returns:
+        - not_run_folders : list
+            folders that don't appear to be a run
+        - completed_old_runs : list
+            completed, stale runs - not to upload
+        - stale_runs : list
+            in-progress, stale run - not to upload
+        - completed_syncable_runs : list
+            completed, non-stale runs - can be uploaded
+        - in_progress_runs : list
+            in-progress, non-stale run - can be uploaded
     """
 
-    not_run_folders, completed_runs, in_progress_runs, stale_runs = ([] for i in range(4))
+    (not_run_folders, completed_syncable_runs, completed_old_runs,
+        in_progress_runs, stale_runs) = ([] for i in range(5))
 
     for run_folder in run_folders:
         folder_path = os.path.join(base_dir, run_folder)
@@ -249,27 +263,34 @@ def check_local_runs(base_dir, run_folders, run_length, n_intervals, novaseq=Fal
             # Not a run_folder
                 not_run_folders.append(run_folder)
         else:
-            # Is a RUN folder
-            if termination_file_exists(folder_path, novaseq):
-                # Is a completed RUN folder
-                completed_runs.append(run_folder)
-            else:
-                # RUN is incomplete, check whether it's stale
-                curr_time = time.time()
-                created_time = os.path.getmtime(run_info_path)
-                time_to_wait = dxpy.utils.normalize_timedelta(run_length) / 1000 * n_intervals
-                if (curr_time - created_time) > time_to_wait:
-                    # Stale run
-                    if DEBUG: print("==DEBUG== run folder {0} was created on {1}; "\
-                    "it is determined to be STALE and will NOT be uploaded.".format(run_folder,
-                        time.strftime("%Z - %Y/%m/%d, %H:%M:%S", time.localtime(created_time))))
+            # Is a RUN folder, check if it is in time to upload or stale
+            curr_time = time.time()
+            created_time = os.path.getmtime(run_info_path)
+            time_to_wait = dxpy.utils.normalize_timedelta(run_length) / 1000 * n_intervals
+            if (curr_time - created_time) > time_to_wait:
+                # Stale run
+                if termination_file_exists(folder_path, novaseq):
+                    # stale run with termination, likely fully uploaded and old
+                    completed_old_runs.append(run_folder)
+                else:
+                    # stale ongoing run => won't be uploded
+                    if DEBUG: print(
+                        f"==DEBUG== run folder {run_folder} was created on "
+                        f"{time.strftime('%Z - %Y/%m/%d, %H:%M:%S', time.localtime(created_time))}; "
+                        "it is determined to be STALE and will NOT be uploaded."
+                        )
 
                     stale_runs.append(run_folder)
+            else:
+                # non-stale run
+                if termination_file_exists(folder_path, novaseq):
+                    # Is a completed RUN folder and still in time to upload
+                    completed_syncable_runs.append(run_folder)
                 else:
                     # Ongoing run
                     in_progress_runs.append(run_folder)
 
-    return (not_run_folders, completed_runs, in_progress_runs, stale_runs)
+    return (not_run_folders, completed_syncable_runs, completed_old_runs, in_progress_runs, stale_runs)
 
 
 def check_dnax_folders(run_folders, project):
@@ -477,24 +498,47 @@ def main():
 
     if DEBUG: print("==DEBUG== Validated config: ", streaming_config)
 
-    (not_runs, completed_runs, ongoing_runs, stale_runs) = check_local_runs(args.directory, run_folders,
-                                                                  streaming_config['run_length'],
-                                                                  streaming_config['n_seq_intervals'], streaming_config.get("novaseq", False))
+    (not_runs, completed_syncable_runs, completed_old_runs,
+    ongoing_runs, stale_runs) = check_local_runs(
+        args.directory,
+        run_folders,
+        streaming_config['run_length'],
+        streaming_config['n_seq_intervals'],
+        streaming_config.get("novaseq", False)
+    )
 
     if DEBUG:
         print("==DEBUG== Searching for run directories in {0}:".format(args.directory))
         if not_runs:
-            print("==DEBUG== Following folders are deemed NOT to be run directories: {0}".format(not_runs))
-        if completed_runs:
-            print("==DEBUG== Following folders are deemed to be COMPLETED runs: {0}".format(completed_runs))
+            print(
+                "==DEBUG== Following folders are deemed NOT to be run "
+                f"directories: {not_runs}"
+            )
+        if completed_syncable_runs:
+            print(
+                "==DEBUG== Following folders are deemed to be COMPLETED runs "
+                f"and IN-PROGRESS: {completed_syncable_runs}"
+            )
         if ongoing_runs:
-            print("==DEBUG== Following folders are deemed to be ONGOING runs: {0}".format(ongoing_runs))
+            print(
+                "==DEBUG== Following folders are deemed to be ONGOING runs: "
+                f"{ongoing_runs}"
+            )
+        if completed_old_runs:
+            print(
+                "==DEBUG== Following folders are completed and old / stale => "
+                f"will not upload: {completed_old_runs}"
+            )
         if stale_runs:
-            print("==DEBUG== Following folders are deeemed to be STALE runs "\
-            "and will not be uploaded: {0}".format(stale_runs))
+            print(
+                "==DEBUG== Following folders are deeemed to be STALE runs "
+                f"and will not be uploaded: {stale_runs}"
+            )
 
-    syncable_folders = completed_runs + ongoing_runs
+    # get lists of runs that are not stale and can check to be uploaded
+    syncable_folders = completed_syncable_runs + ongoing_runs
     (synced_folders, unsynced_folders) = check_dnax_folders(syncable_folders, args.project)
+
     if DEBUG: print("==DEBUG== Got synced folders: ", synced_folders)
     if DEBUG: print("==DEBUG== Got unsynced folders: ", unsynced_folders)
 
@@ -508,7 +552,7 @@ def main():
     folders_to_sync += unsynced_folders
     folders_to_sync = ["{0}/{1}".format(args.directory, folder) for folder in folders_to_sync]
 
-    if DEBUG: "==DEBUG== Folders to sync: {0}".format(folders_to_sync)
+    if DEBUG: print("==DEBUG== Folders to sync: {0}".format(folders_to_sync))
 
     trigger_streaming_upload(folders_to_sync, streaming_config)
 

--- a/files/monitor_runs.py
+++ b/files/monitor_runs.py
@@ -230,8 +230,8 @@ def get_run_folders(base_dir):
 
 
 def check_local_runs(base_dir, run_folders, run_length, n_intervals, novaseq=False):
-    """ Check local folders to ascertain which are Illumina RUN directories (defined
-    as containing a RunInfo.xml file in root of the folder).
+    """ Check local folders to ascertain which are Illumina RUN directories
+    (defined as containing a RunInfo.xml file in root of the folder).
 
     Classify such RUN folders into 3 classes:
      - Completed runs (has a RunInfo.xml and a RTAComplete.txt/xml file)

--- a/files/monitor_runs.py
+++ b/files/monitor_runs.py
@@ -554,6 +554,32 @@ def main():
 
     if DEBUG: print("==DEBUG== Folders to sync: {0}".format(folders_to_sync))
 
+    # write a log file to users home directory to track the current
+    # state of runs picked up in monitored directory
+    state_log = os.path.join(
+        os.path.expanduser('~'), f'{args.sequencer_id}_all_runs_state.log'
+    )
+    with open(state_log, 'w') as fh:
+        fh.write(
+            f"Current state of detected runs for {args.sequencer_id} "
+            f"monitoring {args.directory}\n"
+        )
+        fh.write(f"\n\nNot run directories:")
+        [fh.write(f"\n\t{x}") for x in not_runs]
+
+        fh.write(f"\n\nCompleted runs still uploading:")
+        [fh.write(f"\n\t{x}") for x in completed_syncable_runs]
+
+        fh.write("\n\nOngoing runs still uploading:")
+        [fh.write(f"\n\t{x}") for x in ongoing_runs]
+
+        fh.write("\n\nOld runs that appear to be complete => will NOT be uploaded:")
+        [fh.write(f"\n\t{x}") for x in completed_old_runs]
+
+        fh.write("\n\nOngoing stale runs => will NOT be uploaded:")
+        [fh.write(f"\n\t{x}") for x in stale_runs]
+        fh.write(f"\n")
+
     trigger_streaming_upload(folders_to_sync, streaming_config)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix to stop picking up older 'stale' runs (older than allowed time limit from config, default: 48 hours). Currently, any completed run will be checked for local state vs state in DNAnexus, and if there is a difference it will try to reupload files. This is an issue if a run is deleted in DNAnexus after uploading fully, as the log file contains file ids that don't exist, causing continual errors to be raised and the log file to be repeatedly uploaded. Example run can be seen [here](https://platform.dnanexus.com/panx/projects/FpVG0G84X7kzq58g19vF1YJQ/data/220421_A01295_0088_AHWLCYDSX2/runs).

## Changes

- Fix for issue described above, every run is first checked if it is stale, if so these are split into stale and completed (shouldn't be an issue, just logged), and stale and incomplete, where functionality from before is unchanged. Any non-stale run will either be completed (presence of `CopyComplete.txt`) and will be checked if it is fully uploaded, or ongoing and will continue syncing.
- Fix for #11 
- Added writing current state of all identified runs in monitored directory to a log file in users home directory to make it easier to know what has been picked up
  - Example from test script of a new run:
  ```
  root@aae25ffd23da:/home/dx-upload# cat /root/A01295_all_runs_state.log 
  Current state of detected runs for A01295 monitoring /home/dx-upload/test_runs/A01295

  Not run directories:

  Completed runs still uploading:
          A01295_17574_1_test_upload

  Ongoing runs still uploading:

  Old runs that appear to be complete => will NOT be uploaded:

  Ongoing stale runs => will NOT be uploaded:
  ```
  - Example from server where everything is uploaded:
  ```
    root@a193f92872a0:/home/dx-upload# cat /root/A01295_all_runs_state.log
    Current state of detected runs for A01295 monitoring /genetics/A01295
    Not run directories:
            MyRun
    Completed runs still uploading:
    Ongoing runs still uploading:
    Old runs that appear to be complete => will NOT be uploaded:
            220404_A01295_0078_AH3T5VDRX2
            220404_A01295_0079_BH3T57DRX2
            220407_A01295_0081_BH3G2CDRX2
            220411_A01295_0083_BH5WJHDMXY
            220414_A01295_0085_BH2W27DRX2
            220419_A01295_0087_AHC3FHDMXY
            220421_A01295_0088_AHWLCYDSX2
            220426_A01295_0091_BH3WH5DRX2
            220426_A01295_0090_AH3WHGDRX2
            220428_A01295_0092_AH3WKKDRX2
            220429_A01295_0093_BH3WJYDRX2
            220511_A01295_0094_BH3VVNDRX2
            220513_A01295_0095_BH3W7KDRX2
            220513_A01295_0096_AH2WVNDRX2
            220527_A01295_0102_BH53TKDRX2
            220527_A01295_0101_AH52VFDRX2
            220601_A01295_0103_AH52N7DRX2
            220615_A01295_0104_AH53YJDRX2
            220615_A01295_0105_BH53N2DRX2
            220624_A01295_0106_BH3NWFDRX2
            220701_A01295_0107_BH55CKDRX2
            220226_A01303_0062_BHYKH7DRXY
            220316_A01295_0069_BH333TDRX2
            220318_A01295_0070_AH32MVDRX2
            220330_A01295_0077_AH3T7WDRX2
            220407_A01295_0080_AH333YDRX2
            220408_A01295_0082_AH332CDRX2
            220414_A01295_0084_AH2VWVDRX2
            220419_A01295_0086_BH2W2JDRX2
            220421_A01295_0089_BHK3CHDSX3
    Ongoing stale runs => will NOT be uploaded:
  ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dx-streaming-upload/12)
<!-- Reviewable:end -->
