### PR TITLE
Fix reading notify.log files

### DIFF
--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -417,10 +417,11 @@ def main():
         print(f"Runs already notified from {notify_log}:\n {log}")
 
     if not args.run_dir in log:
-        # first time trying upload
+        # first time trying upload, log and send slack notification
         with open(notify_log, 'a') as fh:
             # add run to log to not send another notification
             fh.write(f"{args.run_dir}\n")
+
         try:
             Slack().send(
                 message=(

--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -412,7 +412,9 @@ def main():
     notify_log = notify_log.replace('"', '').replace("'", "")
 
     with open(notify_log, 'a+') as fh:
+        fh.seek(0)
         log = ' '.join(fh.readlines())
+        print(f"Runs already notified from {notify_log}:\n {log}")
 
     if not args.run_dir in log:
         # first time trying upload


### PR DESCRIPTION
Actually set file pointer to beginning of file to read in runs that have been logged, currently always returns empty list so will always send a Slack notification instead of being suppressed 🤦

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dx-streaming-upload/13)
<!-- Reviewable:end -->
