### PR TITLE
Add experiment name and upload location URL to Slack notifications

### DIFF
--- a/docker-tests/docker_test.sh
+++ b/docker-tests/docker_test.sh
@@ -48,10 +48,14 @@ main() {
 
 
     # create malformed and duplicate samplesheet names to test regex matching and uploading
-    touch /home/dx-upload/test_runs/A01295/${A01295_1}/samplesheet_for_run_A01295_${A01295_1}.csv \
-          /home/dx-upload/test_runs/A01303/${A01303_1}/SampleSheet.csv \
-          /home/dx-upload/test_runs/A01625/${A01625_1}/SampleSheet.csv \
-          /home/dx-upload/test_runs/A01625/${A01625_1}/SampleSheetDuplicate.csv
+    # add experiment name to A01295 and A01303 that will upload to test parsing out for
+    # sending in Slack notification
+    echo "Experiment Name: experiment_name_from_samplesheet_A01295" > \
+        /home/dx-upload/test_runs/A01295/${A01295_1}/samplesheet_for_run_A01295_${A01295_1}.csv
+    echo "Experiment Name: experiment_name_from_samplesheet_A01303" > \
+        /home/dx-upload/test_runs/A01303/${A01303_1}/SampleSheet.csv
+    touch /home/dx-upload/test_runs/A01625/${A01625_1}/SampleSheet.csv \
+        /home/dx-upload/test_runs/A01625/${A01625_1}/SampleSheetDuplicate.csv
 
 
     # create RunInfo.xml files with IDs added

--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -449,9 +449,9 @@ def main():
                 f"starting upload of run *{run_id}*\n"
             )
             if experiment:
-                message += f"\nExperiment name: {experiment}\n"
+                message += f"\nExperiment name: *{experiment}*\n"
 
-            message += f"\nUpload location: {url}\n\n\{usage}"
+            message += f"\nUpload location: {url}\n\n{usage}"
 
             Slack().send(message, run=run_id, log=True)
         except Exception as e:

--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -738,7 +738,7 @@ def main():
         message=(
             f":white_check_mark: dx-streaming-upload: "
             f"run successfully uploaded *{run_id}*\n"
-            f"\t\t\tUpload location: {url}"
+            f"\t\t\tUpload location: {url}\n"
             f"\t\t\tTotal upload time: {total_time}\n"
             f"\t\t\tTotal size of run: {run_size}GB\n"
             f"\t\t\tDisk usage after upload: {usage}"

--- a/files/notify.py
+++ b/files/notify.py
@@ -198,8 +198,8 @@ def parse_samplesheet(run_dir):
     run_dir : str
         directory of run
 
-    Returns : str
-        path to samplesheet
+    Returns : str | None
+        path to samplesheet | None if no samplesheet or > 1 samplesheets found
     """
     files = os.listdir(run_dir)
     files = [

--- a/files/notify.py
+++ b/files/notify.py
@@ -186,3 +186,49 @@ class CheckCycles():
         max_cycles = [max(x) for x in max_cycles]
 
         return lanes, max_cycles
+
+
+def parse_samplesheet(run_dir):
+    """
+    Use regex to find samplesheets in given run directory and parse out
+    experiment name
+
+    Parameters
+    ----------
+    run_dir : str
+        directory of run
+
+    Returns : str
+        path to samplesheet
+    """
+    files = os.listdir(run_dir)
+    files = [
+        re.search('.*sample[-_ ]?sheet.*.csv$', x, re.IGNORECASE) for x in files
+    ]
+    files = [x.group(0) for x in files if x]
+
+    if len(files) == 0:
+        # no samplesheet found
+        print("No samplesheet found")
+        return None
+
+    if len(files) > 1:
+        # more than one samplesheet found, return None and this is handled
+        # in incremental_upload
+        print(f"More than one samplesheet found: {files}")
+
+    try:
+        print(f'Found samplesheet: {files[0]}')
+        with open(os.path.join(run_dir, files[0])) as fh:
+            content = fh.read().splitlines()
+            experiment_name = [x for x in content if x.startswith('Experiment')]
+            experiment_name = experiment_name[0].replace(
+                'Experiment Name', '').replace(',', '').replace('\n', '')
+    except Exception as error:
+        # catch anything that might raise an error to not stop uploading
+        print('Error parsing experiment name from samplesheet')
+        return None
+
+    return experiment_name
+
+

--- a/files/notify.py
+++ b/files/notify.py
@@ -223,7 +223,7 @@ def parse_samplesheet(run_dir):
             content = fh.read().splitlines()
             experiment_name = [x for x in content if x.startswith('Experiment')]
             experiment_name = experiment_name[0].replace(
-                'Experiment Name', '').replace(',', '').replace('\n', '')
+                'Experiment Name:', '').replace(',', '').replace('\n', '')
     except Exception as error:
         # catch anything that might raise an error to not stop uploading
         print('Error parsing experiment name from samplesheet')

--- a/files/notify.py
+++ b/files/notify.py
@@ -216,6 +216,7 @@ def parse_samplesheet(run_dir):
         # more than one samplesheet found, return None and this is handled
         # in incremental_upload
         print(f"More than one samplesheet found: {files}")
+        return None
 
     try:
         print(f'Found samplesheet: {files[0]}')

--- a/files/notify.py
+++ b/files/notify.py
@@ -230,5 +230,3 @@ def parse_samplesheet(run_dir):
         return None
 
     return experiment_name
-
-


### PR DESCRIPTION
## Changes

- Adds experiment name parsed from samplesheet if available to Slack upload notification to know what is uploading
- Adds upload location URL to start and complete notifications
- Closes #15 

- Start notification **with** experiment name present in samplesheet:
![image](https://user-images.githubusercontent.com/45037268/181719102-76e8dc0a-3ddd-4953-9b8e-b296a881d451.png)


- Start notification **without** experiment name present in samplesheet:
![image](https://user-images.githubusercontent.com/45037268/181719202-de788d29-8aaa-4916-90a2-64cc3c45bee3.png)


- Completed upload notification:
![image](https://user-images.githubusercontent.com/45037268/181719341-2e19a31c-e525-4c7b-bea3-a6e0d4f2ea90.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dx-streaming-upload/16)
<!-- Reviewable:end -->
