### PR TITLE
Experiment name

### DIFF
--- a/docker-tests/docker_test_w_app.sh
+++ b/docker-tests/docker_test_w_app.sh
@@ -65,7 +65,7 @@ main() {
 
     # create some files with enough size (2GB each) to trigger an upload
     printf "\nCreating test files...\n\n"
-    dd if=/dev/urandom of=/home/dx-upload/test_runs/A01295/${A01295_1}/Data/Intensities/BaseCalls/L001/C318.1/output.dat bs=500 count=1000000
+    dd if=/dev/urandom of=/home/dx-upload/test_runs/A01295/${A01295_1}/Data/Intensities/BaseCalls/L001/C318.1/output.dat bs=500 count=100000
     
     # create CopyComplete.txt so the runs are flagged as complete and will upload and close
     touch /home/dx-upload/test_runs/A01295/${A01295_1}/CopyComplete.txt

--- a/docker-tests/test_files/test-playbook-template_w_app.yml
+++ b/docker-tests/test_files/test-playbook-template_w_app.yml
@@ -8,7 +8,7 @@
         exclude_patterns: Analysis
         monitored_directories:
           - /home/dx-upload/test_runs/A01295/
-        min_size: 250
+        min_size: 10
         max_size: 1000
         min_interval: 60
         novaseq: True

--- a/docker-tests/test_files/test_samplesheet.csv
+++ b/docker-tests/test_files/test_samplesheet.csv
@@ -1,7 +1,7 @@
 [Header],,,,,,,,
 IEMFileVersion,4,,,,,,,
 Investigator,mrInvestigator,,,,,,,
-Experiment,dx-streaming-upload-testing,,,,,,,
+Experiment,,,dx-streaming-upload-testing,,,,,
 Date,Mon Jan 1 14:33:55 GMT 1991,,,,,,,
 Workflow,GenerateFASTQ,,,,,,,
 Application,NovaSeq FASTQ Only,,,,,,,

--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -739,7 +739,7 @@ def main():
         f"run successfully uploaded *{run_id}*\n"
     )
     if experiment:
-        message += f"\nExperiment name: *{experiment}*\n"
+        message += f"\t\t\tExperiment name: *{experiment}*\n"
     message += (
         f"\t\t\tUpload location: {url}\n"
         f"\t\t\tTotal upload time: {total_time}\n"

--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -734,16 +734,20 @@ def main():
         )
 
     # send slack notification to log channel of successful upload
-    Slack().send(
-        message=(
-            f":white_check_mark: dx-streaming-upload: "
-            f"run successfully uploaded *{run_id}*\n"
-            f"\t\t\tUpload location: {url}\n"
-            f"\t\t\tTotal upload time: {total_time}\n"
-            f"\t\t\tTotal size of run: {run_size}GB\n"
-            f"\t\t\tDisk usage after upload: {usage}"
-        ), run=run_id, log=True
+    message=(
+        f":white_check_mark: dx-streaming-upload: "
+        f"run successfully uploaded *{run_id}*\n"
     )
+    if experiment:
+        message += f"\nExperiment name: *{experiment}*\n"
+    message += (
+        f"\t\t\tUpload location: {url}\n"
+        f"\t\t\tTotal upload time: {total_time}\n"
+        f"\t\t\tTotal size of run: {run_size}GB\n"
+        f"\t\t\tDisk usage after upload: {usage}"
+    )
+
+    Slack().send(message=message, run=run_id, log=True)
 
     downstream_input = {}
     if args.downstream_input:
@@ -779,14 +783,6 @@ def main():
             # Prepare output folder, if downstream analysis specified
             reads_target_folder = get_target_folder(REMOTE_READS_FOLDER, lane)
             print_stderr("Creating output folder %s" %(reads_target_folder))
-
-            try:
-                project.new_folder(reads_target_folder, parents=True)
-            except dxpy.DXError as e:
-                raise_error(
-                    "Failed to create new folder %s. %s" %(reads_target_folder, e),
-                    send=True, run=run_id
-                )
 
             # Decide on job name (<executable>-<run_id>)
             job_name = applet.title + "-" + run_id

--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -780,10 +780,6 @@ def main():
             # applet verified in check_input, assume no change
             applet = dxpy.get_handler(args.applet)
 
-            # Prepare output folder, if downstream analysis specified
-            reads_target_folder = get_target_folder(REMOTE_READS_FOLDER, lane)
-            print_stderr("Creating output folder %s" %(reads_target_folder))
-
             # Decide on job name (<executable>-<run_id>)
             job_name = applet.title + "-" + run_id
 
@@ -791,10 +787,11 @@ def main():
             downstream_input["upload_sentinel_record"] = dxpy.dxlink(record)
 
             # Run specified applet
-            job = applet.run(downstream_input,
-                        folder=reads_target_folder,
-                        project=args.project,
-                        name=job_name)
+            job = applet.run(
+                downstream_input,
+                project=args.project,
+                name=job_name
+            )
 
             print_stderr("Initiated job %s from applet %s for lane %s" %(job, args.applet, lane))
     # Close if args.applet
@@ -816,14 +813,6 @@ def main():
             # Prepare output folder, if downstream analysis specified
             analyses_target_folder = get_target_folder(REMOTE_ANALYSIS_FOLDER, lane)
             print_stderr("Creating output folder %s" %(analyses_target_folder))
-
-            try:
-                project.new_folder(analyses_target_folder, parents=True)
-            except dxpy.DXError as e:
-                raise_error(
-                    "Failed to create new folder %s. %s" %(analyses_target_folder, e),
-                    send=True, run=run_id
-                )
 
             # Decide on job name (<executable>-<run_id>)
             job_name = workflow.title + "-" + run_id

--- a/files/notify.py
+++ b/files/notify.py
@@ -223,7 +223,9 @@ def parse_samplesheet(run_dir):
         with open(os.path.join(run_dir, files[0])) as fh:
             content = fh.read().splitlines()
             experiment_name = [x for x in content if x.startswith('Experiment')]
-            experiment_name = experiment_name[0].split(',')[1]
+            # handle experiment name not being in 2nd column
+            experiment_name = re.sub(r',{1,}', ',', experiment_name[0])
+            experiment_name = experiment_name.split(',')[1]
     except Exception as error:
         # catch anything that might raise an error to not stop uploading
         print('Error parsing experiment name from samplesheet')


### PR DESCRIPTION
- remove creation of empty `reads` folder in upload project
  - fixes #25
  - 
![image](https://github.com/eastgenomics/dx-streaming-upload/assets/45037268/778d8886-9fde-42e3-abb5-b24319767f1d)

- Improve parsing of experiment name from samplesheet in cases of where it isn't in the 2nd column, and add to the final upload notification so we know what it is that has uploaded easier
  - closes #19 
  - closes #23 
  - 
![image](https://github.com/eastgenomics/dx-streaming-upload/assets/45037268/342de60b-7699-4fb8-a508-7113da4c1702)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dx-streaming-upload/30)
<!-- Reviewable:end -->
