### PR TITLE
IN682 - handle duplicated samplesheets in run data

### DIFF
--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -439,7 +439,8 @@ def find_local_samplesheet(run_directory, run_id) -> Union[str, bool]:
         halt_downstream = False
 
     elif len(files) == 1:
-        local_sample_sheet = 'SampleSheet.csv'
+        print(f"Found one samplesheet to use: {files[0]}")
+        local_sample_sheet = files[0]
         halt_downstream = False
 
     elif len(files) == 2 and check_identical_samplesheets(
@@ -448,7 +449,8 @@ def find_local_samplesheet(run_directory, run_id) -> Union[str, bool]:
     ):
         # found 2 samplesheets, test if they are identical and we can
         # just select one to upload and associate to the sentinel record
-        local_sample_sheet = 'SampleSheet.csv'
+        print(f"Found 2 identical samplesheets, will upload {files[0]}")
+        local_sample_sheet = files[0]
         halt_downstream = False
 
     else:

--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -398,9 +398,8 @@ def find_local_samplesheet(run_directory, run_id) -> Union[str, bool]:
     Find the samplesheet(s) in the local run data directory.
 
     The following behaviour is performed:
-        - no samplesheet found -> returns the string of default samplesheet
-            name 'SampleSheet.csv' to continue downstream behaviour
-            correctly
+        - no samplesheet found -> send error alert that samplesheet missing
+            but don't halt downstream analysis
         - 1 samplesheet found -> return name of samplesheet
         - 2 samplesheets found -> test if they have identical contents,
             if so return the first, if not send error alert and return

--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -428,6 +428,8 @@ def find_local_samplesheet(run_directory, run_id) -> Union[str, bool]:
     files = [x.group(0) for x in files if x]
     print_stderr(f"Found samplesheet(s): {files}")
 
+    halt_downstream = False
+
     if len(files) == 0:
         # send an alert so we know no samplesheet has been added
         Slack().send(
@@ -436,12 +438,10 @@ def find_local_samplesheet(run_directory, run_id) -> Union[str, bool]:
             ), run=run_id, alert=True
         )
         local_sample_sheet = None
-        halt_downstream = False
 
     elif len(files) == 1:
         print(f"Found one samplesheet to use: {files[0]}")
         local_sample_sheet = files[0]
-        halt_downstream = False
 
     elif len(files) == 2 and check_identical_samplesheets(
         os.path.join(run_directory, files[0]),
@@ -451,7 +451,6 @@ def find_local_samplesheet(run_directory, run_id) -> Union[str, bool]:
         # just select one to upload and associate to the sentinel record
         print(f"Found 2 identical samplesheets, will upload {files[0]}")
         local_sample_sheet = files[0]
-        halt_downstream = False
 
     else:
         # more than one found and not the same file, continue the

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.realpath(__file__), "../../"))
+)
+
+TEST_DATA_DIR = (
+    os.path.join(os.path.dirname(__file__), 'test_data')
+)

--- a/tests/test_incremental_upload.py
+++ b/tests/test_incremental_upload.py
@@ -2,37 +2,71 @@ import sys
 import os
 import tempfile
 import shutil
+import unittest
+
 import pytest
 
-src_dir = os.path.join(os.path.dirname(__file__), "..")
-files_dir = os.path.join(src_dir, "files")
-sys.path.append(files_dir)
-import incremental_upload as iu
+from files import incremental_upload as iu
+from tests import TEST_DATA_DIR
 
 
-def create_files(rtacomplete_txt, rtacomplete_xml, copycomplete_txt):
-    tmp_folder = tempfile.mkdtemp()
-    if rtacomplete_txt:
-        with open(tmp_folder + "/RTAComplete.txt", 'w') as RTAComplete_txt:
-            RTAComplete_txt.write("foo")
-    if rtacomplete_xml:
-        with open(tmp_folder + "/RTAComplete.xml", 'w') as RTAComplete_xml:
-            RTAComplete_xml.write("bar")
-    if copycomplete_txt:
-        with open(tmp_folder + "/CopyComplete.txt", 'w') as CopyComplete_txt:
-            CopyComplete_txt.write("foobar")
-    return tmp_folder
+# def create_files(rtacomplete_txt, rtacomplete_xml, copycomplete_txt):
+#     tmp_folder = tempfile.mkdtemp()
+#     if rtacomplete_txt:
+#         with open(tmp_folder + "/RTAComplete.txt", 'w') as RTAComplete_txt:
+#             RTAComplete_txt.write("foo")
+#     if rtacomplete_xml:
+#         with open(tmp_folder + "/RTAComplete.xml", 'w') as RTAComplete_xml:
+#             RTAComplete_xml.write("bar")
+#     if copycomplete_txt:
+#         with open(tmp_folder + "/CopyComplete.txt", 'w') as CopyComplete_txt:
+#             CopyComplete_txt.write("foobar")
+#     return tmp_folder
 
 
-# parametrized with ((RTAComplete.txt, RTAComplete.xml, CopyComplete.txt), result, result_novaseq)
-@pytest.mark.parametrize("permutation,result,result_novaseq", [((False, False, False), False, False), ((False, False, True), False, True),
-                                                               ((False, True, False), True, False), ((False, True, True), True, True),
-                                                               ((True, False, False), True, False), ((True, False, True), True, True),
-                                                               ((True, True, False), True, False), ((True, True, True), True, True)])
-def test_termination_file_exists(permutation, result, result_novaseq):
-    run_dir = create_files(*permutation)
-    actual = iu.termination_file_exists(False, run_dir)
-    actual_novaseq = iu.termination_file_exists(True, run_dir)
-    shutil.rmtree(run_dir)  # deleting before potential assert failure
-    assert actual == result
-    assert actual_novaseq == result_novaseq
+# # parametrized with ((RTAComplete.txt, RTAComplete.xml, CopyComplete.txt), result, result_novaseq)
+# @pytest.mark.parametrize("permutation,result,result_novaseq", [((False, False, False), False, False), ((False, False, True), False, True),
+#                                                                ((False, True, False), True, False), ((False, True, True), True, True),
+#                                                                ((True, False, False), True, False), ((True, False, True), True, True),
+#                                                                ((True, True, False), True, False), ((True, True, True), True, True)])
+# def test_termination_file_exists(permutation, result, result_novaseq):
+#     run_dir = create_files(*permutation)
+#     actual = iu.termination_file_exists(False, run_dir)
+#     actual_novaseq = iu.termination_file_exists(True, run_dir)
+#     shutil.rmtree(run_dir)  # deleting before potential assert failure
+#     assert actual == result
+#     assert actual_novaseq == result_novaseq
+
+
+
+class TestCheckIdenticalSamplesheets(unittest.TestCase):
+    """
+    Tests for incremental_upload.check_identical_samplesheets
+
+    Function takes 2 samplesheets to check if the contents are identical
+    (i.e one is a copy of the other)
+    """
+
+    def test_identical_files_returns_true(self):
+        """
+        Test when file contents are identical that the function returns
+        True
+        """
+        identical = iu.check_identical_samplesheets(
+            samplesheet_1=os.path.join(TEST_DATA_DIR, 'SampleSheet.csv'),
+            samplesheet_2=os.path.join(TEST_DATA_DIR, 'SampleSheet_copy.csv')
+        )
+
+        assert identical, 'Identical files not correctly identified'
+
+
+    def test_different_files_return_false(self):
+        """
+        Test when file contents differer that function returns False
+        """
+        identical = iu.check_identical_samplesheets(
+            samplesheet_1=os.path.join(TEST_DATA_DIR, 'SampleSheet.csv'),
+            samplesheet_2=os.path.join(TEST_DATA_DIR, 'SampleSheet_different.csv')
+        )
+
+        assert not identical, 'Differing files not correctly identified'

--- a/tests/test_incremental_upload.py
+++ b/tests/test_incremental_upload.py
@@ -1,42 +1,10 @@
-import sys
 import os
-import tempfile
-import shutil
 import unittest
 
 import pytest
 
 from files import incremental_upload as iu
 from tests import TEST_DATA_DIR
-
-
-# def create_files(rtacomplete_txt, rtacomplete_xml, copycomplete_txt):
-#     tmp_folder = tempfile.mkdtemp()
-#     if rtacomplete_txt:
-#         with open(tmp_folder + "/RTAComplete.txt", 'w') as RTAComplete_txt:
-#             RTAComplete_txt.write("foo")
-#     if rtacomplete_xml:
-#         with open(tmp_folder + "/RTAComplete.xml", 'w') as RTAComplete_xml:
-#             RTAComplete_xml.write("bar")
-#     if copycomplete_txt:
-#         with open(tmp_folder + "/CopyComplete.txt", 'w') as CopyComplete_txt:
-#             CopyComplete_txt.write("foobar")
-#     return tmp_folder
-
-
-# # parametrized with ((RTAComplete.txt, RTAComplete.xml, CopyComplete.txt), result, result_novaseq)
-# @pytest.mark.parametrize("permutation,result,result_novaseq", [((False, False, False), False, False), ((False, False, True), False, True),
-#                                                                ((False, True, False), True, False), ((False, True, True), True, True),
-#                                                                ((True, False, False), True, False), ((True, False, True), True, True),
-#                                                                ((True, True, False), True, False), ((True, True, True), True, True)])
-# def test_termination_file_exists(permutation, result, result_novaseq):
-#     run_dir = create_files(*permutation)
-#     actual = iu.termination_file_exists(False, run_dir)
-#     actual_novaseq = iu.termination_file_exists(True, run_dir)
-#     shutil.rmtree(run_dir)  # deleting before potential assert failure
-#     assert actual == result
-#     assert actual_novaseq == result_novaseq
-
 
 
 class TestCheckIdenticalSamplesheets(unittest.TestCase):

--- a/tests/test_incremental_upload.py
+++ b/tests/test_incremental_upload.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 import unittest
+from unittest.mock import patch
 
 import pytest
 
@@ -38,3 +40,140 @@ class TestCheckIdenticalSamplesheets(unittest.TestCase):
         )
 
         assert not identical, 'Differing files not correctly identified'
+
+
+class TestFindLocalSamplesheet(unittest.TestCase):
+    """
+    Tests for find_local_samplesheet.
+
+    Function finds local samplesheet(s) and returns the name of the
+    selected local file and if to halt downstream analysis in the case
+    of multiple non-identical samplesheets being identified.
+    """
+    test_run_dir = os.path.join(TEST_DATA_DIR, 'test_run_dir')
+
+    def setUp(self):
+        os.mkdir(self.test_run_dir)
+
+
+    def tearDown(self):
+        shutil.rmtree(self.test_run_dir, )
+
+
+    @patch('files.incremental_upload.Slack')
+    def test_no_samplesheet(self, mock_slack):
+        """
+        Test that when no samplesheet is found that we send a Slack alert
+        and return local samplesheet as None and not to halt downstream
+        analysis
+        """
+        local_samplesheet, halt_downstream = iu.find_local_samplesheet(
+            run_directory=self.test_run_dir,
+            run_id='test_run'
+        )
+
+        with self.subTest('Slack alert not sent'):
+            assert mock_slack.call_count == 1
+
+        with self.subTest('local samplesheet wrongly returned'):
+            assert not local_samplesheet
+
+        with self.subTest('halt downstream wrongly set'):
+            assert not halt_downstream
+
+
+    def test_find_one_samplesheet(self):
+        """
+        Test when we find one samplesheet named `SampleSheet.csv` that we
+        correctly return it and halt_downstream as False
+        """
+        shutil.copy(
+            os.path.join(TEST_DATA_DIR, 'SampleSheet.csv'),
+            os.path.join(self.test_run_dir, 'SampleSheet.csv')
+        )
+
+        local_samplesheet, halt_downstream = iu.find_local_samplesheet(
+            run_directory=self.test_run_dir,
+            run_id='test_run'
+        )
+
+        with self.subTest('SampleSheet.csv not returned'):
+            assert local_samplesheet == 'SampleSheet.csv'
+
+        with self.subTest('halt_downstream not returned False'):
+            assert not halt_downstream
+
+    @patch(
+        'files.incremental_upload.check_identical_samplesheets',
+        wraps=iu.check_identical_samplesheets
+    )
+    def test_two_identical_samplesheets_found(self, mock_check):
+        """
+        Test when we find 2 differently named samplesheets with identical
+        contents that we return the first and halt_downstream as False
+        """
+        shutil.copy(
+            os.path.join(TEST_DATA_DIR, 'SampleSheet.csv'),
+            os.path.join(self.test_run_dir, 'SampleSheet.csv')
+        )
+
+        shutil.copy(
+            os.path.join(TEST_DATA_DIR, 'SampleSheet_copy.csv'),
+            os.path.join(self.test_run_dir, 'SampleSheet_copy.csv')
+        )
+
+        local_samplesheet, halt_downstream = iu.find_local_samplesheet(
+            run_directory=self.test_run_dir,
+            run_id='test_run'
+        )
+
+        with self.subTest('found incorrect samplesheet'):
+            assert local_samplesheet == 'SampleSheet.csv'
+
+        with self.subTest('halt_downstream not returned False'):
+            assert not halt_downstream
+
+        with self.subTest('check_identical_samplesheets not called'):
+            # check we actually call the function to compare samplesheets
+            assert mock_check.call_count == 1
+
+
+    @patch('files.incremental_upload.Slack')
+    @patch(
+        'files.incremental_upload.check_identical_samplesheets',
+        wraps=iu.check_identical_samplesheets
+    )
+    def test_two_different_samplesheets(self, mock_check, mock_slack):
+        """
+        Test when we find 2 different samplesheets with different contents
+        that we correctly send a Slack alert, return None for the local
+        samplesheet and return halt_downstream as True
+        """
+        shutil.copy(
+            os.path.join(TEST_DATA_DIR, 'SampleSheet.csv'),
+            os.path.join(self.test_run_dir, 'SampleSheet.csv')
+        )
+
+        shutil.copy(
+            os.path.join(TEST_DATA_DIR, 'SampleSheet_different.csv'),
+            os.path.join(self.test_run_dir, 'SampleSheet_different.csv')
+        )
+
+        local_samplesheet, halt_downstream = iu.find_local_samplesheet(
+            run_directory=self.test_run_dir,
+            run_id='test_run'
+        )
+
+        with self.subTest('local samplesheet wrongly returned'):
+            assert not local_samplesheet
+
+        with self.subTest('halt downstream not correctly set'):
+            assert halt_downstream
+
+        with self.subTest('check_identical_samplesheets not called'):
+            # check we actually call the function to compare samplesheets
+            assert mock_check.call_count == 1
+
+        with self.subTest('Slack alert not sent'):
+            # check we would send the Slack alert
+            assert mock_slack.call_count == 1


### PR DESCRIPTION
- better handles picking up and uploading of samplesheets
- correctly handle duplicate samplesheets because of Illuminas totally normal and sane behaviour of duplicating files in a 'security patch'
- actually add some unit tests for the added behaviour

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dx-streaming-upload/39)
<!-- Reviewable:end -->
