### PR TITLE
add crontab entry to backup monitor log files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ RUN chmod gu+rw /var/run
 RUN chmod gu+s /usr/sbin/cron
 RUN chown 1005 /etc/environment
 
+# add in cron entry for making hourly monitor log backups
+COPY cron/crontab /etc/cron.d/crontab
+RUN chmod 0644 /etc/cron.d/crontab
+RUN crontab /etc/cron.d/crontab
 
 # create required log dir, playbook(s) should point to here
 RUN mkdir /home/dx-upload/logs

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ ansible-playbook /playbooks/dx-upload-play.yml -i inventory --extra-vars "dx_tok
 
 ```
 
-A test script has been written (`docker-tests/docker_test.sh`) to check dx-streaming-upload in the container works as expected. This will simulate 4 instances of dx-streaming-upload are set up to simulate 4 sequencers being monitored concurrently, with 4 different end points of behaviour:
+A test script has been written (`docker-tests/docker_test.sh`) to check dx-streaming-upload in the container works as expected. This will simulate 4 instances of dx-streaming-upload which are set up to simulate 4 sequencers being monitored concurrently, with 4 different end points of behaviour:
 - A01295 -> should upload successfully and send a success notification to
       the logs channel
 - A01303 -> send an alert due to missing cycle dirs

--- a/README.md
+++ b/README.md
@@ -291,8 +291,6 @@ docker run -itd \
 docker exec -it {container-id} bash -c "bash /home/dx-upload/dx-streaming-upload/docker-tests/docker_test.sh {dnanexus-project-id} {dnanexus-auth-token}"
 ```
 
-1ZT1aXcl4639mr52GkMjty145cFXcZVv
-
 **Notes on Docker**
 - Image is created with a user `dx-upload` in the image for running the upload, working dir is `/home/dx-upload/`
 - A minimum of read permissions on the monitored directories and write permission on the `local_tar_directory`. Read/write permission must also be given on any bind mounted directories that may also be written to (i.e. if `local_log_directory` if this is mounted outside of the container (e.g. bound to `/var/log`))

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,0 +1,4 @@
+# start of crontab
+
+# backup monitor logs every hour before they get overwritten for 72 hours
+* * * * * /bin/bash -c 'for log in $(/bin/find ~/ -type f -name "monitor*.log"); do dir=$(sed "s/\(\/root\/monitor_\|.log\)//g" <<< $log); /usr/bin/savelog -C -c 72 -t -q -l -d -D "\%y\%m\%d_\%H\%M" -r /root/monitor_log_backups/$dir/  $log; done' > ~/cron_monitor_log_backup.log 2>&1

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,4 +1,4 @@
 # start of crontab
 
 # backup monitor logs every hour before they get overwritten for 72 hours
-* * * * * /bin/bash -c 'for log in $(/bin/find ~/ -type f -name "monitor*.log"); do dir=$(sed "s/\(\/root\/monitor_\|.log\)//g" <<< $log); /usr/bin/savelog -C -c 72 -t -q -l -d -D "\%y\%m\%d_\%H\%M" -r /root/monitor_log_backups/$dir/  $log; done' > ~/cron_monitor_log_backup.log 2>&1
+59 * * * * /bin/bash -c 'for log in $(/bin/find ~/ -type f -name "monitor*.log"); do dir=$(sed "s/\(\/root\/monitor_\|.log\)//g" <<< $log); /usr/bin/savelog -C -c 72 -t -q -l -d -D "\%y\%m\%d_\%H\%M" -r /root/monitor_log_backups/$dir/  $log; done' > ~/cron_monitor_log_backup.log 2>&1


### PR DESCRIPTION
- adds default backup of monitor log files to `~/monitor_log_backups` in the container on an hourly timed rotation for 72 hours
- fixes #36 
- example run of Docker test scripts results in the following crontab:
```
root@7801fd556715:/home/dx-upload# crontab -l
# start of crontab

# backup monitor logs every hour before they get overwritten for 72 hours
59 * * * * /bin/bash -c 'for log in $(/bin/find ~/ -type f -name "monitor*.log"); do dir=$(sed "s/\(\/root\/monitor_\|.log\)//g" <<< $log); /usr/bin/savelog -C -c 72 -t -q -l -d -D "\%y\%m\%d_\%H\%M" -r /root/monitor_log_backups/$dir/  $log; done' > ~/cron_monitor_log_backup.log 2>&1
#Ansible: DNAnexus monitor runs (debug) /home/dx-upload/test_runs/A01295/
* * * * * flock -w 5 /var/lock/dnanexus_uploader_A01295.lock bash -ex -c 'PATH=/opt/dnanexus-upload-agent:$PATH; python3 /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/A01295_monitor_runs.config -p project-GkxB8y8485XPkGg598G5bKzV --sequencer_id A01295 -d /home/dx-upload/test_runs/A01295/       -v > ~/monitor_A01295.log 2>&1' > ~/dx-stream_cron_A01295.log 2>&1
#Ansible: DNAnexus monitor runs (debug) /home/dx-upload/test_runs/A01303/
* * * * * flock -w 5 /var/lock/dnanexus_uploader_A01303.lock bash -ex -c 'PATH=/opt/dnanexus-upload-agent:$PATH; python3 /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/A01303_monitor_runs.config -p project-GkxB8y8485XPkGg598G5bKzV --sequencer_id A01303 -d /home/dx-upload/test_runs/A01303/       -v > ~/monitor_A01303.log 2>&1' > ~/dx-stream_cron_A01303.log 2>&1
#Ansible: DNAnexus monitor runs (debug) /home/dx-upload/test_runs/A01625/
* * * * * flock -w 5 /var/lock/dnanexus_uploader_A01625.lock bash -ex -c 'PATH=/opt/dnanexus-upload-agent:$PATH; python3 /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/A01625_monitor_runs.config -p project-GkxB8y8485XPkGg598G5bKzV --sequencer_id A01625 -d /home/dx-upload/test_runs/A01625/       -v > ~/monitor_A01625.log 2>&1' > ~/dx-stream_cron_A01625.log 2>&1
```

Modifying the hourly backup to be every minute to show it running produces the following after 2 minutes:
```
root@7801fd556715:/home/dx-upload# find ~/monitor_log_backups/ -type f
/root/monitor_log_backups/A01295/monitor_A01295.log.240625_1323
/root/monitor_log_backups/A01295/monitor_A01295.log.240625_1322
/root/monitor_log_backups/A01625/monitor_A01625.log.240625_1322
/root/monitor_log_backups/A01625/monitor_A01625.log.240625_1323
/root/monitor_log_backups/A01303/monitor_A01303.log.240625_1323
/root/monitor_log_backups/A01303/monitor_A01303.log.240625_1322
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/dx-streaming-upload/41)
<!-- Reviewable:end -->
